### PR TITLE
handle more unquoted strings

### DIFF
--- a/lib/snmp/open/parser.rb
+++ b/lib/snmp/open/parser.rb
@@ -23,7 +23,8 @@ module SNMP
         columns = texts.map do |text|
           tokenized =
             text
-            .gsub(/([0-9\.]+) = STRING: *$/, '\\1 = STRING: ""')
+            .gsub(/([0-9\.]+) = STRING: ((?!")[^\n]*)\n/,
+                  %(\\1 = STRING: "\\2"\n))
             .gsub(Static::ANY_MESSAGE, Static::QUOTED_MESSAGES)
             .shellsplit
           parse_tokens(tokenized)

--- a/spec/snmp/open/parser_spec.rb
+++ b/spec/snmp/open/parser_spec.rb
@@ -53,15 +53,6 @@ module SNMP
         expect(parsed.to_a).to eq expected
       end
 
-      it 'parses Timeticks' do
-        parser = Parser.new(['1.2.3'])
-        texts = ['.1.2.3.0 = Timeticks: (16651183) 1 day, 22:15:11.83']
-        expected = [[Value.new('1.2.3.0', 'Timeticks', 16_651_183)]]
-
-        parsed = parser.parse(texts)
-        expect(parsed.to_a).to eq expected
-      end
-
       it 'handles a single result with an unexpected OID' do
         parser = Parser.new(['1.2.3.4'])
         texts = [".1.2.3.9 = INTEGER: 1\n"]
@@ -74,6 +65,13 @@ module SNMP
         texts = [".1.2.3.1 = STRING: \n.1.2.3.4 = INTEGER: 1\n"]
         parsed = parser.parse(texts)
         expect(parsed.map { |e| e.first.value }).to eq ['', 1]
+      end
+
+      it 'handles an unquoted multi-word string' do
+        parser = Parser.new(['1.2.3'])
+        texts = [".1.2.3.1 = STRING: one two three\n.1.2.3.4 = INTEGER: 1\n"]
+        parsed = parser.parse(texts)
+        expect(parsed.map { |e| e.first.value }).to eq ['one two three', 1]
       end
 
       it 'handles multiline values' do


### PR DESCRIPTION
This works by quoting any unquoted string that doesn't span multiple lines, so we now support:

* unquoted empty strings
* quoted empty strings
* quoted non-empty strings over any number of lines
* unquoted non-empty strings limited to one line containing no double quotes