### PR TITLE
support for symbolic object enumeration in output

### DIFF
--- a/lib/snmp/open/options.rb
+++ b/lib/snmp/open/options.rb
@@ -24,12 +24,10 @@ module SNMP
         host: nil
       }.freeze
 
-      # On some systems, SNMP command outputs will include symbolic OID names,
-      # symbolic values, and/or value units. The parser doesn't support these,
-      # so disable them.
+      # On some systems, SNMP command outputs will include symbolic values
+      # and/or value units. The parser doesn't support these, so disable them.
       REQUIRED_BY_PARSER = {
         '-Oe' => nil,
-        '-On' => nil,
         '-OU' => nil
       }.freeze
 

--- a/spec/snmp/open/command_reader_spec.rb
+++ b/spec/snmp/open/command_reader_spec.rb
@@ -5,54 +5,99 @@ describe SNMP::Open::CommandReader do
   describe '#capture' do
     it 'chomps an error' do
       expect(Open3).to receive(:capture3)
-        .with('blah -Oe -On -OU blah blah')
+        .with('blah -On -Oe -OU blah 1.0.1')
         .and_return(['', "ng\n"])
       expect do
         snmp = SNMP::Open::CommandReader.new(host: 'blah')
-        snmp.capture('blah', 'blah')
+        snmp.capture('blah', '1.0.1')
       end.to raise_error(SNMP::Open::CommandError, 'ng')
     end
 
     it 'raises a precise error for a timeout' do
       expect(Open3).to receive(:capture3)
-        .with('blah -Oe -On -OU blah blah')
+        .with('blah -On -Oe -OU blah 1.0.1')
         .and_return(['', 'Timeout: No Response from blah.'])
       expect do
         snmp = SNMP::Open::CommandReader.new(host: 'blah')
-        snmp.capture('blah', 'blah')
+        snmp.capture('blah', '1.0.1')
       end.to raise_error(SNMP::Open::CommandTimeoutError,
                          'Timeout: No Response from blah.')
     end
 
+    it 'raises a precise error on "Cannot find module"' do
+      message =
+        "MIB search path: /home/me/.snmp/mibs:/usr/share/mibs\n"\
+        "Cannot find module (SNAPv2-MIB): At line 1 in (none)\n"\
+        "SNAP-MIB::sysDescr: Unknown Object Identifier\n"
+
+      expect(Open3).to receive(:capture3)
+        .with('snmpbulkwalk -Oe -OU blah SNAPv2-MIB::sysDescr')
+        .and_return(['', message])
+      snmp = SNMP::Open::CommandReader.new(host: 'blah')
+
+      expect do
+        snmp.capture(:bulkwalk, 'SNAPv2-MIB::sysDescr')
+      end.to raise_error(SNMP::Open::UnknownMIBError,
+                         'Unknown MIB: SNAPv2-MIB')
+    end
+
+    it 'raises a precise error on "Unknown Object Identifier"' do
+      message = "SNMPv2-MIB::sysDescl: Unknown Object Identifier\n"
+
+      expect(Open3).to receive(:capture3)
+        .with('snmpbulkwalk -Oe -OU blah SNMPv2-MIB::sysDescl')
+        .and_return(['', message])
+      snmp = SNMP::Open::CommandReader.new(host: 'blah')
+
+      expect do
+        snmp.capture(:bulkwalk, 'SNMPv2-MIB::sysDescl')
+      end.to raise_error(SNMP::Open::UnknownOIDError,
+                         'Unknown OID: SNMPv2-MIB::sysDescl')
+    end
+
     it 'passes the env to the capture, if given' do
       expect(Open3).to receive(:capture3)
-        .with({ 'EVAR' => 'VAL' }, 'blah -Oe -On -OU blah blah')
+        .with({ 'EVAR' => 'VAL' }, 'blah -On -Oe -OU blah 1.0.1')
         .and_return(['', ''])
       snmp =
         SNMP::Open::CommandReader.new(host: 'blah', env: { 'EVAR' => 'VAL' })
-      snmp.capture('blah', 'blah')
+      snmp.capture('blah', '1.0.1')
     end
   end
 
   describe '#cli' do
+    let(:snmp) { SNMP::Open::CommandReader.new(host: 'example') }
+
     it 'returns the CLI command' do
       snmp = SNMP::Open::CommandReader.new(host: 'example')
-      expect(snmp.cli(:bulkwalk)).to eq 'snmpbulkwalk -Oe -On -OU example'
+      expect(snmp.cli(:bulkwalk)).to eq 'snmpbulkwalk -On -Oe -OU example'
     end
 
     it 'accepts a version option through the constructor' do
       snmp = SNMP::Open::CommandReader.new(host: 'example', version: '2c')
-      expect(snmp.cli(:bulkwalk)).to eq 'snmpbulkwalk -Oe -On -OU -v2c example'
+      expect(snmp.cli(:bulkwalk)).to eq 'snmpbulkwalk -On -Oe -OU -v2c example'
     end
 
     it 'accepts a user option using -u through the constructor' do
       snmp = SNMP::Open::CommandReader.new(host: 'example', '-u' => 'doe')
-      expect(snmp.cli(:bulkwalk)).to eq 'snmpbulkwalk -Oe -On -OU -udoe example'
+      expect(snmp.cli(:bulkwalk)).to eq 'snmpbulkwalk -On -Oe -OU -udoe example'
     end
 
     it 'accepts an object ID' do
       snmp = SNMP::Open::CommandReader.new(host: 'example')
-      expect(snmp.cli(:bulkwalk, '1.2.3.4')).to eq 'snmpbulkwalk -Oe -On -OU example 1.2.3.4'
+      expect(snmp.cli(:bulkwalk, '1.2.3.4')).to eq 'snmpbulkwalk -On -Oe -OU example 1.2.3.4'
+    end
+
+    it 'includes -On without OID' do
+      expect(snmp.cli(:walk)).to match(/ -On /)
+    end
+
+    it 'includes -On with numeric OID' do
+      expect(snmp.cli(:walk, '1.2.3.4')).to match(/ -On /)
+    end
+
+    it 'omits -On with symbolic OID' do
+      expect(snmp.cli(:walk, 'SNMPv2-MIB::sysDescr')).not_to match(/ -On /)
     end
 
     context 'for no_check_increasing' do
@@ -62,17 +107,17 @@ describe SNMP::Open::CommandReader do
 
       it 'includes -Cc for bulkwalk' do
         expect(snmp.cli(:bulkwalk, '1.2.3.4'))
-          .to eq 'snmpbulkwalk -Oe -On -OU example -Cc 1.2.3.4'
+          .to eq 'snmpbulkwalk -On -Oe -OU example -Cc 1.2.3.4'
       end
 
       it 'omits -Cc on get' do
         expect(snmp.cli(:get, '1.2.3.4'))
-          .to eq 'snmpget -Oe -On -OU example 1.2.3.4'
+          .to eq 'snmpget -On -Oe -OU example 1.2.3.4'
       end
 
       it 'includes -Cc for walk' do
         expect(snmp.cli(:walk, '1.2.3.4'))
-          .to eq 'snmpwalk -Oe -On -OU example -Cc 1.2.3.4'
+          .to eq 'snmpwalk -On -Oe -OU example -Cc 1.2.3.4'
       end
     end
   end # describe '#to_s' do

--- a/spec/snmp/open_spec.rb
+++ b/spec/snmp/open_spec.rb
@@ -11,7 +11,7 @@ describe SNMP::Open do
       snmp = SNMP::Open.new(host: 'example.org', env: { 'EVAR' => 'EVAL' })
       expect(Open3)
         .to receive(:capture3)
-        .with({ 'EVAR' => 'EVAL' }, 'snmpget -Oe -On -OU example.org 1.2.3.4')
+        .with({ 'EVAR' => 'EVAL' }, 'snmpget -On -Oe -OU example.org 1.2.3.4')
         .and_return(['', ''])
       snmp.get(['1.2.3.4']).to_a
     end
@@ -31,7 +31,7 @@ describe SNMP::Open do
       objects.each do |object|
         expect(Open3)
           .to receive(:capture3)
-          .with("snmpbulkwalk -Cn0 -Cr10 -Oe -On -OU example #{object[:oid]}")
+          .with("snmpbulkwalk -Cn0 -Cr10 -On -Oe -OU example #{object[:oid]}")
           .and_return([object[:value], ''])
       end
     end


### PR DESCRIPTION
given a mib-prefixed symbolic OID, allow symbolic output, otherwise force
numeric output as before