### PR TITLE
Update value_parser to allow Timeticks values where human readable format does only contain one digit for the hour.

### DIFF
--- a/lib/snmp/open/parser/value_parser.rb
+++ b/lib/snmp/open/parser/value_parser.rb
@@ -81,7 +81,7 @@ module SNMP
 
             # consume tokens through one like 23:59:59.99
             loop do
-              break if tokens.next =~ /\A\d\d:\d\d:\d\d.\d\d\z/
+              break if tokens.next =~ /\A\d?\d:\d\d:\d\d.\d\d\z/
             end
 
             @parse = [@type, ticks]


### PR DESCRIPTION
Hello @bjmllr,

at the moment, the human-readable format needs to have two digits for the hour to stop the detection of the timetick value.

The output of the current net-snmp version also has one digit values for the hour if the hour is less than 10:
```
.1.3.6.1.2.1.2.2.1.9.1259 = Timeticks: (173102037) 20 days, 0:50:20.37
.1.3.6.1.2.1.2.2.1.9.1260 = Timeticks: (173102037) 20 days, 0:50:20.37
.1.3.6.1.2.1.2.2.1.9.1261 = Timeticks: (181388238) 20 days, 23:51:22.38
.1.3.6.1.2.1.2.2.1.9.1262 = Timeticks: (181388238) 20 days, 23:51:22.38
.1.3.6.1.2.1.2.2.1.9.1263 = Timeticks: (191801) 0:31:58.01
.1.3.6.1.2.1.2.2.1.9.1264 = Timeticks: (721) 0:00:07.21
```

This pull request changes the regex, so that the first digit of the hour is optional.

```
snmpbulkwalk -V
NET-SNMP version: 5.9.4.pre2
```